### PR TITLE
Creating demo target db structures

### DIFF
--- a/db/Catalog/README.md
+++ b/db/Catalog/README.md
@@ -1,0 +1,22 @@
+# catalog
+**catalog** is supposed to mimic a real-life example of a metaphor use-case. It represents a target database schema which stores metadata for tables and columns. The end-users are supposed to provide metadata regarding the systems/tables/columns that they want their target database to hold. An automated process can then read the normalised catalog structures and actually perform the create statements to sync up with the physical database.
+
+## Table dictionary
+
+`catalog.system`: Defines source systems that may contain multiple tables
+`catalog.instance`: Defines instances of source systems
+`catalog.schema`: Defines schemas that store tables
+`catalog.table`: Defines tables of source systems that are stored in schemas
+`catalog.column`: Defines attributes of columns within tables
+
+## Folder structure
+```bash
+│   catalog.sql : "creates the catalog schema."
+│
+└───tables : "holds all table definitions within catalog"
+        column.sql
+        instance.sql
+        schema.sql
+        system.sql
+        table.sql
+```

--- a/db/Catalog/README.md
+++ b/db/Catalog/README.md
@@ -3,11 +3,11 @@
 
 ## Table dictionary
 
-`catalog.system`: Defines source systems that may contain multiple tables
-`catalog.instance`: Defines instances of source systems
-`catalog.schema`: Defines schemas that store tables
-`catalog.table`: Defines tables of source systems that are stored in schemas
-`catalog.column`: Defines attributes of columns within tables
+- `catalog.system`: Defines source systems that may contain multiple tables
+- `catalog.instance`: Defines instances of source systems
+- `catalog.schema`: Defines schemas that store tables
+- `catalog.table`: Defines tables of source systems that are stored in schemas
+- `catalog.column`: Defines attributes of columns within tables
 
 ## Folder structure
 ```bash

--- a/db/Catalog/Tables/column.sql
+++ b/db/Catalog/Tables/column.sql
@@ -1,0 +1,21 @@
+CREATE TABLE catalog.column
+(
+    id              INT GENERATED ALWAYS AS IDENTITY,
+    name            VARCHAR(128) NOT NULL,
+    description     VARCHAR(1000) NULL,
+    ordinal         SMALLINT NOT NULL,
+    data_type       VARCHAR(15) NOT NULL,
+    length          SMALLINT NULL,
+    precision       SMALLINT NULL,
+    scale           SMALLINT NULL,
+    nullable        BOOLEAN NOT NULL CONSTRAINT df_nullable DEFAULT FALSE,
+    column_default  VARCHAR(80) NULL,
+    table_id        INT NOT NULL,
+    created_on      TIMESTAMP NOT NULL CONSTRAINT df_created_on DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      INT NOT NULL CONSTRAINT df_created_on DEFAULT 0,
+    deleted_on      TIMESTAMP NULL,
+
+    CONSTRAINT pk_column PRIMARY KEY (id),
+    CONSTRAINT fk_column_table FOREIGN KEY (table_id) REFERENCES catalog.table(id),
+    CONSTRAINT uc_column_name_table UNIQUE (name, table_id, deleted_on)
+);

--- a/db/Catalog/Tables/instance.sql
+++ b/db/Catalog/Tables/instance.sql
@@ -1,0 +1,14 @@
+CREATE TABLE catalog.instance 
+(
+    id              INT GENERATED ALWAYS AS IDENTITY,
+    name            VARCHAR(128) NOT NULL,
+    description     VARCHAR(1000) NULL,
+    system_id       INT NOT NULL,
+    created_on      TIMESTAMP NOT NULL CONSTRAINT df_created_on DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      INT NOT NULL CONSTRAINT df_created_on DEFAULT 0,
+    deleted_on      TIMESTAMP NULL,
+
+    CONSTRAINT pk_instance PRIMARY KEY (id),
+    CONSTRAINT fk_instance_system FOREIGN KEY (system_id) REFERENCES catalog.system(id),
+    CONSTRAINT uc_instance_name UNIQUE (name, system_id, deleted_on)
+);

--- a/db/Catalog/Tables/schema.sql
+++ b/db/Catalog/Tables/schema.sql
@@ -1,0 +1,12 @@
+CREATE TABLE catalog.schema
+(
+    id              INT GENERATED ALWAYS AS IDENTITY,
+    name            VARCHAR(128) NOT NULL,
+    description     VARCHAR(1000) NULL,
+    created_on      TIMESTAMP NOT NULL CONSTRAINT df_created_on DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      INT NOT NULL CONSTRAINT df_created_on DEFAULT 0,
+    deleted_on      TIMESTAMP NULL,
+
+    CONSTRAINT pk_schema PRIMARY KEY (id),
+    CONSTRAINT uc_schema_name UNIQUE (name, deleted_on)
+);

--- a/db/Catalog/Tables/system.sql
+++ b/db/Catalog/Tables/system.sql
@@ -1,0 +1,12 @@
+CREATE TABLE catalog.system 
+(
+    id              INT GENERATED ALWAYS AS IDENTITY,
+    name            VARCHAR(128) NOT NULL,
+    description     VARCHAR(1000) NULL,
+    created_on      TIMESTAMP NOT NULL CONSTRAINT df_created_on DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      INT NOT NULL CONSTRAINT df_created_on DEFAULT 0,
+    deleted_on      TIMESTAMP NULL,
+
+    CONSTRAINT pk_system PRIMARY KEY (id),
+    CONSTRAINT uc_system_name UNIQUE (name, deleted_on)
+);

--- a/db/Catalog/Tables/table.sql
+++ b/db/Catalog/Tables/table.sql
@@ -1,0 +1,16 @@
+CREATE TABLE catalog.table
+(
+    id              INT GENERATED ALWAYS AS IDENTITY,
+    name            VARCHAR(128) NOT NULL,
+    description     VARCHAR(1000) NULL,
+    schema_id       INT NOT NULL,
+    instance_id     INT NOT NULL,
+    created_on      TIMESTAMP NOT NULL CONSTRAINT df_created_on DEFAULT CURRENT_TIMESTAMP,
+    is_deleted      INT NOT NULL CONSTRAINT df_created_on DEFAULT 0,
+    deleted_on      TIMESTAMP NULL,
+
+    CONSTRAINT pk_table PRIMARY KEY (id),
+    CONSTRAINT fk_table_schema FOREIGN KEY (schema_id) REFERENCES catalog.schema(id),
+    CONSTRAINT fk_table_instance FOREIGN KEY (instance_id) REFERENCES catalog.instance(id),
+    CONSTRAINT uc_table_name_schema UNIQUE (name, schema_id, deleted_on)
+);

--- a/db/Catalog/catalog.sql
+++ b/db/Catalog/catalog.sql
@@ -1,0 +1,1 @@
+CREATE SCHEMA catalog;


### PR DESCRIPTION
Another good day for metaphor! 🔥

I have created some demo database structures for a normalised target db which holds catalog data. 

A few facts:
- I added a readme with a short readme on what this is about
- I used postgres flavour (in line with @krzykrzy's PR

Next:
- I stored this in `metaphor/db/catalog` but supposing this is a target client env and not an internal db. I think I am going to follow @krzykrzy approach and store it in `metaphor\prototyping\db`, once this is merged in. 
- As a new issue, I want to extend #4 and add a database deployment step in the container to create all created db structures


Resolves #2 